### PR TITLE
Bugfix: Arreglar Task de documentacion local con Sphinx

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "whitenoise>=6.8.2",
     "pyotp>=2.9.0",
     "qrcode[pil]>=7.4.2",
+    "sqlparse>=0.4.4",
 ]
 
 [project.optional-dependencies]

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -27,6 +27,7 @@ dependencies = [
     { name = "pycountry" },
     { name = "pyotp" },
     { name = "qrcode", extra = ["pil"] },
+    { name = "sqlparse" },
     { name = "whitenoise" },
 ]
 
@@ -69,6 +70,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=8.2.3" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'dev'", specifier = ">=3.2.0" },
     { name = "sphinx-rtd-theme", marker = "extra == 'dev'", specifier = ">=3.0.2" },
+    { name = "sqlparse", specifier = ">=0.4.4" },
     { name = "whitenoise", specifier = ">=6.8.2" },
 ]
 provides-extras = ["dev"]

--- a/dev-commands.json
+++ b/dev-commands.json
@@ -236,8 +236,8 @@
         "sphinx-build",
         "-b",
         "html",
-        "docs",
-        "docs/_build/html"
+        "../docs",
+        "../docs/_build/html"
       ],
       "cwd": "app"
     },


### PR DESCRIPTION
Se modifico la ruta del comando del task y se agrego dependencia de sqlparse que es dependencia de django y por algun motivo Sphinx necesita para crear su documentacion en el entorno local.